### PR TITLE
Verify if the metric extracted from the 'sdiag' output is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,67 @@
 # Prometheus Slurm Exporter
 
-Prometheus collector and exporter for metric form the [Slurm](https://slurm.schedmd.com/overview.html) resource scheduling system.
+Prometheus collector and exporter for metrics extracted from the [Slurm](https://slurm.schedmd.com/overview.html) resource scheduling system.
 
-Cf. Prometheus documentation:
+## Exported Metrics
 
-* [Package Documentation](https://godoc.org/github.com/prometheus/client_golang/prometheus)
-* [Metric Types](https://prometheus.io/docs/concepts/metric_types/)
-* [Writing Exporters](https://prometheus.io/docs/instrumenting/writing_exporters/)
+### State of the Nodes
+
+* **Allocated**: nodes which has been allocated to one or more jobs.
+* **Completing**: all jobs associated with these nodes are in the process of being completed.
+* **Down**:  nodes which are unavailable for use.
+* **Fail**: these nodes are expected to fail soon and are unavailable for use per system administrator request.
+* **Error**: nodes which are currently in an error state and not capable of running any jobs.
+* **Idle**: nodes not allocated to any jobs and thus available for use.
+* **Maint**: nodes which are currently marked with the __maintenance__ flag.
+* **Mixed**: nodes which have some of their CPUs ALLOCATED while others are IDLE.
+* **Resv**: these nodes are in an advanced reservation and not generally available.
+
+[Information extracted from the SLURM **sinfo** command](https://slurm.schedmd.com/sinfo.html)
+
+### Status of the Jobs
+
+* **PENDING**: Jobs awaiting for resource allocation.
+* **RUNNING**: Jobs currently allocated.
+* **SUSPENDED**: Job has an allocation but execution has been suspended and CPUs have been released for other jobs.
+* **CANCELLED**: Jobs which were explicitly cancelled by the user or system administrator.
+* **COMPLETING**: Jobs which are in the process of being completed.
+* **COMPLETED**: Jobs have terminated all processes on all nodes with an exit code of zero.
+* **CONFIGURING**: Jobs have been allocated resources, but are waiting for them to become ready for use.
+* **FAILED**: Jobs terminated with a non-zero exit code or other failure condition.
+* **TIMEOUT**: Jobs terminated upon reaching their time limit.
+* **PREEMPTED**: Jobs terminated due to preemption.
+* **NODE_FAIL**: Jobs terminated due to failure of one or more allocated nodes.
+
+[Information extracted from the SLURM **squeue** command](https://slurm.schedmd.com/squeue.html)
+
+### Scheduler Information
+
+* **Server Thread count**: The number of current active ``slurmctld`` threads. 
+* **Queue size**: The length of the scheduler queue.
+* **Last cycle**: Time in microseconds for last scheduling cycle.
+* **Mean cycle**: Mean of scheduling cycles since last reset.
+* **Cycles per minute**: Counter of scheduling executions per minute.
+* **(Backfill) Last cycle**: Time in microseconds of last backfilling cycle.
+* **(Backfill) Mean cycle**: Mean of backfilling scheduling cycles in microseconds since last reset.
+* **(Backfill) Depth mean**: Mean of processed jobs during backfilling scheduling cycles since last reset.
+
+[Information extracted from the SLURM **sdiag** command](https://slurm.schedmd.com/sdiag.html)
+
+## How to install the exporter
 
 Install the Prometheus [Go client library](https://github.com/prometheus/client_golang)
 
     >>> apt install -t jessie-backports golang-github-prometheus-client-golang-dev
 
 Use the [Makefile](Makefile) to build and test the code.
+
+## Prometheus references
+
+* [GOlang Package Documentation](https://godoc.org/github.com/prometheus/client_golang/prometheus)
+* [Metric Types](https://prometheus.io/docs/concepts/metric_types/)
+* [Writing Exporters](https://prometheus.io/docs/instrumenting/writing_exporters/)
+* [Available Exporters](https://prometheus.io/docs/instrumenting/exporters/)
+
 
 ## License
 

--- a/scheduler.go
+++ b/scheduler.go
@@ -55,6 +55,8 @@ func SchedulerData() []byte {
 
 // Helper function to split a single line from the sdiag output
 func SplitColonValueToFloat(input string) float64 {
+  // Verify if the string extracted from the sdiag output is empty
+  if input == "" { return 0 }
   str := strings.Split(input,":")
   rvalue := strings.TrimSpace(str[1])
   flt, _ := strconv.ParseFloat(rvalue,64)


### PR DESCRIPTION
The output reported by ``sdiag`` is not always providing all the metrics expected by the exporter. 
In the case of a new Slurm cluster, the code is expecting to extract certain metrics related to the 
backfill stats (e.g. ``Depth Mean``) which cannot be there, unless the cluster is subjected to an
heavy stress test.

In order to avoid a panic crash, the proposed pull request will always verify the string extracted
from the ``sdiag`` output and if empty will set the value to zero.