### PR TITLE
Use official exporter port (9341)

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ scrape_configs:
     scrape_timeout:   30s
 
     static_configs:
-      - targets: ['slurm_host.fqdn:8080']
+      - targets: ['slurm_host.fqdn:9341']
 ```
 
 * **scrape_interval**: a 30 seconds interval will avoid possible 'overloading' on the SLURM master due to frequent calls of sdiag/squeue/sinfo commands through the exporter.

--- a/main.go
+++ b/main.go
@@ -32,7 +32,7 @@ func init() {
 
 var listenAddress = flag.String(
   "listen-address",
-  ":8080",
+  ":9341",
   "The address to listen on for HTTP requests.")
 
 func main() {


### PR DESCRIPTION
The exporter has an [officially assigned port](https://github.com/prometheus/prometheus/wiki/Default-port-allocations). Update from port 8080 to
9341.


Signed-off-by: Justin Lecher <justin.lecher@astrazeneca.com>