### PR TITLE
Use `localhost` in README.md instead of `slurm_host.fqdn`

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ scrape_configs:
     scrape_timeout:   30s
 
     static_configs:
-      - targets: ['slurm_host.fqdn:8080']
+      - targets: ['localhost:8080']
 ```
 
 * **scrape_interval**: a 30 seconds interval will avoid possible 'overloading' on the SLURM master due to frequent calls of sdiag/squeue/sinfo commands through the exporter.


### PR DESCRIPTION
Wouldn't it be better to recommend `localhost` in `README.md`? This would prevent issue #6 when people like me blindly copy text.