### PR TITLE
Include all partitions in squeue

### DIFF
--- a/queue.go
+++ b/queue.go
@@ -84,7 +84,7 @@ func ParseQueueMetrics(input []byte) *QueueMetrics {
 
 // Execute the squeue command and return its output
 func QueueData() []byte {
-	cmd := exec.Command("/usr/bin/squeue", "-r", "-h", "-o %A,%T,%r", "--states=all")
+	cmd := exec.Command("/usr/bin/squeue", "-a", "-r", "-h", "-o %A,%T,%r", "--states=all")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
If running slurm_exporter as a non-priviledged user and have multiple partitions the squeue command will not show you all jobs, but only ones that the user can access. The easiest solution is to add the '-a' flag to squeue to see all partitions, including hidden partitions.