### PR TITLE
GRES (GPU) metric collection

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -44,6 +44,13 @@ Start the exporter (foreground), and query all metrics:
 ```bash
 bin/prometheus-slurm-exporter
 ...
+
+If you wish to run the exporter on a different port, or the default port (8080) is already in use, run with the following argument:
+
+```bash
+bin/prometheus-slurm-exporter --listen-address="0.0.0.0:<port>"
+...
+
 # query all metrics (default port)
 curl http://localhost:8080/metrics
 ```

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,7 +30,7 @@ go mod download
 Build the exporter:
 
 ```bash
-go build -o bin/prometheus-slurm-exporter {main,accounts,cpus,gpus,nodes,queue,scheduler,users}.go
+go build -o bin/prometheus-slurm-exporter {main,accounts,cpus,gpus,partitions,nodes,queue,scheduler,users}.go
 ```
 
 Run all tests included in `_test.go` files:

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,7 +30,7 @@ go mod download
 Build the exporter:
 
 ```bash
-go build -o bin/prometheus-slurm-exporter {main,accounts,cpus,nodes,queue,scheduler,users}.go
+go build -o bin/prometheus-slurm-exporter {main,accounts,cpus,gpus,nodes,queue,scheduler,users}.go
 ```
 
 Run all tests included in `_test.go` files:
@@ -56,4 +56,3 @@ References:
 * [Metric Types](https://prometheus.io/docs/concepts/metric_types/)
 * [Writing Exporters](https://prometheus.io/docs/instrumenting/writing_exporters/)
 * [Available Exporters](https://prometheus.io/docs/instrumenting/exporters/)
-

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Prometheus collector and exporter for metrics extracted from the [Slurm](https:/
 ### State of the GPUs
 
 * **Allocated**: GPUs which have been allocated to a job.
-* **Idle**: GPUs not allocated to a job and thus available for use.
 * **Other**: GPUs which are unavailable for use at the moment.
 * **Total**: total number of GPUs.
+* **Utilization**: total GPU utiliazation on the cluster.
 
 - Information extracted from the SLURM [**sinfo**](https://slurm.schedmd.com/sinfo.html) and [**sacct**](https://slurm.schedmd.com/sacct.html) command.
 - [Slurm GRES scheduling](https://slurm.schedmd.com/gres.html)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Prometheus collector and exporter for metrics extracted from the [Slurm](https:/
 * **Other**: CPUs which are unavailable for use at the moment.
 * **Total**: total number of CPUs.
 
-- [Information extracted from the SLURM **sinfo** command](https://slurm.schedmd.com/sinfo.html)
+- Information extracted from the SLURM [**sinfo**](https://slurm.schedmd.com/sinfo.html) command.
 - [Slurm CPU Management User and Administrator Guide](https://slurm.schedmd.com/cpu_management.html)
 
 ### State of the GPUs
@@ -21,7 +21,7 @@ Prometheus collector and exporter for metrics extracted from the [Slurm](https:/
 * **Other**: GPUs which are unavailable for use at the moment.
 * **Total**: total number of GPUs.
 
-- [Information extracted from the SLURM **sinfo** command](https://slurm.schedmd.com/sinfo.html)
+- Information extracted from the SLURM [**sinfo**](https://slurm.schedmd.com/sinfo.html) and [**sacct**](https://slurm.schedmd.com/sacct.html) command.
 - [Slurm GRES scheduling](https://slurm.schedmd.com/gres.html)
 
 ### State of the Nodes

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ visualize the exported metrics through [Grafana](https://grafana.com):
 
 ## License
 
-Copyright 2017-2020 Victor Penso, Matteo Dessalvi, Joeri Hermans
+Copyright 2017-2020 Victor Penso, Matteo Dessalvi
 
 This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,16 @@ Prometheus collector and exporter for metrics extracted from the [Slurm](https:/
 - [Information extracted from the SLURM **sinfo** command](https://slurm.schedmd.com/sinfo.html)
 - [Slurm CPU Management User and Administrator Guide](https://slurm.schedmd.com/cpu_management.html)
 
+### State of the GPUs
+
+* **Allocated**: GPUs which have been allocated to a job.
+* **Idle**: GPUs not allocated to a job and thus available for use.
+* **Other**: GPUs which are unavailable for use at the moment.
+* **Total**: total number of GPUs.
+
+- [Information extracted from the SLURM **sinfo** command](https://slurm.schedmd.com/sinfo.html)
+- [Slurm GRES scheduling](https://slurm.schedmd.com/gres.html)
+
 ### State of the Nodes
 
 * **Allocated**: nodes which has been allocated to one or more jobs.
@@ -57,7 +67,7 @@ The following information about jobs are also extracted via [squeue](https://slu
 
 ### Scheduler Information
 
-* **Server Thread count**: The number of current active ``slurmctld`` threads. 
+* **Server Thread count**: The number of current active ``slurmctld`` threads.
 * **Queue size**: The length of the scheduler queue.
 * **DBD Agent queue size**: The length of the message queue for _SlurmDBD_.
 * **Last cycle**: Time in microseconds for last scheduling cycle.
@@ -74,7 +84,7 @@ The following information about jobs are also extracted via [squeue](https://slu
 
 *DBD Agent queue size*: it is particularly important to keep track of it, since an increasing number of messages
 counted with this parameter almost always indicates three issues:
-* the _SlurmDBD_ daemon is down; 
+* the _SlurmDBD_ daemon is down;
 * the database is either down or unreachable;
 * the status of the Slurm accounting DB may be inconsistent (e.g. ``sreport`` missing data, weird utilization of the cluster, etc.).
 
@@ -82,7 +92,7 @@ counted with this parameter almost always indicates three issues:
 ## Installation
 
 * Read [DEVELOPMENT.md](DEVELOPMENT.md) in order to build the Prometheus Slurm Exporter. After a successful build copy the executable
-`bin/prometheus-slurm-exporter` to a node with access to the Slurm command-line interface. 
+`bin/prometheus-slurm-exporter` to a node with access to the Slurm command-line interface.
 
 * A [Systemd Unit][sdu] file to run the executable as service is available in [lib/systemd/prometheus-slurm-exporter.service](lib/systemd/prometheus-slurm-exporter.service).
 
@@ -99,7 +109,7 @@ scrape_configs:
 
 #
 # SLURM resource manager:
-# 
+#
   - job_name: 'my_slurm_exporter'
 
     scrape_interval:  30s
@@ -146,5 +156,3 @@ This is free software: you can redistribute it and/or modify it under the terms 
 This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License along with this program. If not, see http://www.gnu.org/licenses/.
-
-

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ visualize the exported metrics through [Grafana](https://grafana.com):
 
 ## License
 
-Copyright 2017-2020 Victor Penso, Matteo Dessalvi
+Copyright 2017-2020 Victor Penso, Matteo Dessalvi, Joeri Hermans
 
 This is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Prometheus collector and exporter for metrics extracted from the [Slurm](https:/
 * **Mixed**: nodes which have some of their CPUs ALLOCATED while others are IDLE.
 * **Resv**: these nodes are in an advanced reservation and not generally available.
 
-[Information extracted from the SLURM **sinfo** command](https://slurm.schedmd.com/sinfo.html)
+- Information extracted from the SLURM [**sinfo**](https://slurm.schedmd.com/sinfo.html) command.
 
 ### Status of the Jobs
 
@@ -56,7 +56,7 @@ Prometheus collector and exporter for metrics extracted from the [Slurm](https:/
 * **PREEMPTED**: Jobs terminated due to preemption.
 * **NODE_FAIL**: Jobs terminated due to failure of one or more allocated nodes.
 
-[Information extracted from the SLURM **squeue** command](https://slurm.schedmd.com/squeue.html)
+- Information extracted from the SLURM [**squeue**](https://slurm.schedmd.com/squeue.html) command.
 
 ### Jobs information per Account and UserID
 
@@ -80,7 +80,7 @@ The following information about jobs are also extracted via [squeue](https://slu
 * **(Backfill) Total Backfilled Jobs** (since last stats cycle start): number of jobs started thanks to backfilling since last time stats where reset.
 * **(Backfill) Total backfilled heterogeneous Job components**: number of heterogeneous job components started thanks to backfilling since last Slurm start.
 
-[Information extracted from the SLURM **sdiag** command](https://slurm.schedmd.com/sdiag.html)
+- Information extracted from the SLURM [**sdiag**](https://slurm.schedmd.com/sdiag.html) command.
 
 *DBD Agent queue size*: it is particularly important to keep track of it, since an increasing number of messages
 counted with this parameter almost always indicates three issues:

--- a/gpus.go
+++ b/gpus.go
@@ -47,8 +47,7 @@ func ParseOtherGPUs() float64 {
 
 func ParseTotalGPUs() float64 {
 	args := []string{"-h", "-o \"%n %G\""}
-	output := Execute("sinfo", args)
-	log.Fatal(output)
+	output := string(Execute("sinfo", args))
 
 	return 10.0 // TODO Implement
 }

--- a/gpus.go
+++ b/gpus.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os/exec"
+	"strings"
 )
 
 type GPUsMetrics struct {
@@ -48,8 +49,14 @@ func ParseOtherGPUs() float64 {
 func ParseTotalGPUs() float64 {
 	args := []string{"-h", "-o \"%n %G\""}
 	output := string(Execute("sinfo", args))
+	if len(output) > 0 {
+		for _, line := range strings.Split(output, "\n") {
+			descriptor := strings.Split(line, " ")[0]
+			log.Fatal(descriptor)
+		}
+	}
 
-	return 10.0 // TODO Implement
+	return 0.0
 }
 
 func ParseGPUsMetrics() *GPUsMetrics {

--- a/gpus.go
+++ b/gpus.go
@@ -17,8 +17,8 @@ package main
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/common/log"
 	"io/ioutil"
-	"log"
 	"os/exec"
 	"strings"
 )
@@ -51,8 +51,9 @@ func ParseTotalGPUs() float64 {
 	output := string(Execute("sinfo", args))
 	if len(output) > 0 {
 		for _, line := range strings.Split(output, "\n") {
+			log.Infof("Line %s: ", line)
 			descriptor := strings.Split(line, " ")[0]
-			log.Fatal(descriptor)
+			log.Infof("Descriptor %s: ", descriptor)
 		}
 	}
 

--- a/gpus.go
+++ b/gpus.go
@@ -71,6 +71,7 @@ func ParseTotalGPUs() float64 {
 				node_gpus, err :=  strconv.ParseFloat(descriptor, 64)
 				log.Infof("Number of GPUs %f", node_gpus)
 				if err != nil {
+					log.Infof("Adding GPUs %f", node_gpus)
 					num_gpus += node_gpus
 				}
 			}

--- a/gpus.go
+++ b/gpus.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os/exec"
 	"strings"
+	"strconv"
 )
 
 type GPUsMetrics struct {
@@ -47,19 +48,26 @@ func ParseOtherGPUs() float64 {
 }
 
 func ParseTotalGPUs() float64 {
+	var num_gpus = 0.0
+
 	args := []string{"-h", "-o \"%n %G\""}
 	output := string(Execute("sinfo", args))
 	if len(output) > 0 {
 		for _, line := range strings.Split(output, "\n") {
 			if len(line) > 0 {
-				log.Infof("Line %s: ", line)
-				descriptor := strings.Split(line, " ")[0]
-				log.Infof("Descriptor %s: ", descriptor)
+				line = strings.Trim(line, "\"")
+				descriptor := strings.Fields(line)[1]
+				descriptor = strings.TrimPrefix(descriptor, "gpu:")
+				descriptor = strings.Split(descriptor, "(")[0]
+				node_gpus, err :=  strconv.ParseFloat(descriptor, 64)
+				if err != nil {
+					num_gpus += node_gpus
+				}
 			}
 		}
 	}
 
-	return 0.0
+	return num_gpus
 }
 
 func ParseGPUsMetrics() *GPUsMetrics {

--- a/gpus.go
+++ b/gpus.go
@@ -20,8 +20,6 @@ import (
 	"io/ioutil"
 	"log"
 	"os/exec"
-	"strconv"
-	"strings"
 )
 
 type GPUsMetrics struct {
@@ -48,25 +46,25 @@ func ParseOtherGPUs() float64 {
 }
 
 func ParseTotalGPUs() float64 {
-	args := []string{"sinfo", "-h", "-o \"%n %G\""}
-	output := Execute(args)
-	log.Info(output)
+	args := []string{"-h", "-o \"%n %G\""}
+	output := Execute("sinfo", args)
+	log.Fatal(output)
 
 	return 10.0 // TODO Implement
 }
 
 func ParseGPUsMetrics() *GPUsMetrics {
 	var gm GPUsMetrics
-	gm.alloc, _ = ParseAllocatedGPUs()
-	gm.idle, _ = ParseIdleGPUs()
-	gm.other, _ = ParseOtherGPUs()
-	gm.total, _ = ParseTotalGPUs()
+	gm.alloc = ParseAllocatedGPUs()
+	gm.idle = ParseIdleGPUs()
+	gm.other = ParseOtherGPUs()
+	gm.total = ParseTotalGPUs()
 	return &gm
 }
 
 // Execute the sinfo command and return its output
-func Execute(arguments []string) []byte {
-	cmd := exec.Command(arguments...)
+func Execute(command string, arguments []string) []byte {
+	cmd := exec.Command(command, arguments...)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		log.Fatal(err)

--- a/gpus.go
+++ b/gpus.go
@@ -32,24 +32,41 @@ type GPUsMetrics struct {
 }
 
 func GPUsGetMetrics() *GPUsMetrics {
-	return ParseGPUsMetrics(GPUsData())
+	return ParseGPUsMetrics()
 }
 
-func ParseGPUsMetrics(input []byte) *GPUsMetrics {
+func ParseAllocatedGPUs() float64 {
+	return 0.0 // TODO Implement
+}
+
+func ParseIdleGPUs() float64 {
+	return 0.0 // TOOD Implement
+}
+
+func ParseOtherGPUs() float64 {
+	return 0.0 // TODO Implement
+}
+
+func ParseTotalGPUs() float64 {
+	args := []string{"sinfo", "-h", "-o \"%n %G\""}
+	output := Execute(args)
+	log.Info(output)
+
+	return 10.0 // TODO Implement
+}
+
+func ParseGPUsMetrics() *GPUsMetrics {
 	var gm GPUsMetrics
-	if strings.Contains(string(input), "/") {
-		splitted := strings.Split(strings.TrimSpace(string(input)), "/")
-		gm.alloc, _ = strconv.ParseFloat(splitted[0], 64)
-		gm.idle, _ = strconv.ParseFloat(splitted[1], 64)
-		gm.other, _ = strconv.ParseFloat(splitted[2], 64)
-		gm.total, _ = strconv.ParseFloat(splitted[3], 64)
-	}
+	gm.alloc, _ = ParseAllocatedGPUs()
+	gm.idle, _ = ParseIdleGPUs()
+	gm.other, _ = ParseOtherGPUs()
+	gm.total, _ = ParseTotalGPUs()
 	return &gm
 }
 
 // Execute the sinfo command and return its output
-func GPUsData() []byte {
-	cmd := exec.Command("sinfo", "-h", "-o %C")
+func Execute(arguments []string) []byte {
+	cmd := exec.Command(arguments...)
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		log.Fatal(err)

--- a/gpus.go
+++ b/gpus.go
@@ -51,9 +51,11 @@ func ParseTotalGPUs() float64 {
 	output := string(Execute("sinfo", args))
 	if len(output) > 0 {
 		for _, line := range strings.Split(output, "\n") {
-			log.Infof("Line %s: ", line)
-			descriptor := strings.Split(line, " ")[0]
-			log.Infof("Descriptor %s: ", descriptor)
+			if len(line) > 0 {
+				log.Infof("Line %s: ", line)
+				descriptor := strings.Split(line, " ")[0]
+				log.Infof("Descriptor %s: ", descriptor)
+			}
 		}
 	}
 

--- a/gpus.go
+++ b/gpus.go
@@ -69,6 +69,7 @@ func ParseTotalGPUs() float64 {
 				descriptor = strings.TrimPrefix(descriptor, "gpu:")
 				descriptor = strings.Split(descriptor, "(")[0]
 				node_gpus, err :=  strconv.ParseFloat(descriptor, 64)
+				log.Infof("Number of GPUs %f", node_gpus)
 				if err != nil {
 					num_gpus += node_gpus
 				}

--- a/gpus.go
+++ b/gpus.go
@@ -1,0 +1,102 @@
+/* Copyright 2020 Joeri Hermans, Victor Penso, Matteo Dessalvi
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>. */
+
+package main
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"io/ioutil"
+	"log"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+type GPUsMetrics struct {
+	alloc float64
+	idle  float64
+	other float64
+	total float64
+}
+
+func GPUsGetMetrics() *GPUsMetrics {
+	return ParseGPUsMetrics(GPUsData())
+}
+
+func ParseGPUsMetrics(input []byte) *GPUsMetrics {
+	var gm GPUsMetrics
+	if strings.Contains(string(input), "/") {
+		splitted := strings.Split(strings.TrimSpace(string(input)), "/")
+		gm.alloc, _ = strconv.ParseFloat(splitted[0], 64)
+		gm.idle, _ = strconv.ParseFloat(splitted[1], 64)
+		gm.other, _ = strconv.ParseFloat(splitted[2], 64)
+		gm.total, _ = strconv.ParseFloat(splitted[3], 64)
+	}
+	return &gm
+}
+
+// Execute the sinfo command and return its output
+func GPUsData() []byte {
+	cmd := exec.Command("sinfo", "-h", "-o %C")
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		log.Fatal(err)
+	}
+	if err := cmd.Start(); err != nil {
+		log.Fatal(err)
+	}
+	out, _ := ioutil.ReadAll(stdout)
+	if err := cmd.Wait(); err != nil {
+		log.Fatal(err)
+	}
+	return out
+}
+
+/*
+ * Implement the Prometheus Collector interface and feed the
+ * Slurm scheduler metrics into it.
+ * https://godoc.org/github.com/prometheus/client_golang/prometheus#Collector
+ */
+
+func NewGPUsCollector() *GPUsCollector {
+	return &GPUsCollector{
+		alloc: prometheus.NewDesc("slurm_gpus_alloc", "Allocated GPUs", nil, nil),
+		idle:  prometheus.NewDesc("slurm_gpus_idle", "Idle GPUs", nil, nil),
+		other: prometheus.NewDesc("slurm_gpus_other", "Mix GPUs", nil, nil),
+		total: prometheus.NewDesc("slurm_gpus_total", "Total GPUs", nil, nil),
+	}
+}
+
+type GPUsCollector struct {
+	alloc *prometheus.Desc
+	idle  *prometheus.Desc
+	other *prometheus.Desc
+	total *prometheus.Desc
+}
+
+// Send all metric descriptions
+func (cc *GPUsCollector) Describe(ch chan<- *prometheus.Desc) {
+	ch <- cc.alloc
+	ch <- cc.idle
+	ch <- cc.other
+	ch <- cc.total
+}
+func (cc *GPUsCollector) Collect(ch chan<- prometheus.Metric) {
+	cm := GPUsGetMetrics()
+	ch <- prometheus.MustNewConstMetric(cc.alloc, prometheus.GaugeValue, cm.alloc)
+	ch <- prometheus.MustNewConstMetric(cc.idle, prometheus.GaugeValue, cm.idle)
+	ch <- prometheus.MustNewConstMetric(cc.other, prometheus.GaugeValue, cm.other)
+	ch <- prometheus.MustNewConstMetric(cc.total, prometheus.GaugeValue, cm.total)
+}

--- a/gpus.go
+++ b/gpus.go
@@ -45,10 +45,8 @@ func ParseAllocatedGPUs() float64 {
 			if len(line) > 0 {
 				line = strings.Trim(line, "\"")
 				descriptor := strings.TrimPrefix(line, "gpu:")
-				job_gpus, err := strconv.ParseFloat(descriptor, 64)
-				if err != nil {
-					num_gpus += job_gpus
-				}
+				job_gpus, _ := strconv.ParseFloat(descriptor, 64)
+				num_gpus += job_gpus
 			}
 		}
 	}
@@ -68,12 +66,8 @@ func ParseTotalGPUs() float64 {
 				descriptor := strings.Fields(line)[1]
 				descriptor = strings.TrimPrefix(descriptor, "gpu:")
 				descriptor = strings.Split(descriptor, "(")[0]
-				node_gpus, err :=  strconv.ParseFloat(descriptor, 64)
-				log.Infof("Number of GPUs %f", node_gpus)
-				if err != nil {
-					log.Infof("Adding GPUs %f", node_gpus)
-					num_gpus += node_gpus
-				}
+				node_gpus, _ :=  strconv.ParseFloat(descriptor, 64)
+				num_gpus += node_gpus
 			}
 		}
 	}

--- a/main.go
+++ b/main.go
@@ -1,4 +1,4 @@
-/* Copyright 2017-2020 Victor Penso, Matteo Dessalvi
+/* Copyright 2017-2020 Victor Penso, Matteo Dessalvi, Joeri Hermans
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/main.go
+++ b/main.go
@@ -25,13 +25,14 @@ import (
 
 func init() {
 	// Metrics have to be registered to be exposed
-	prometheus.MustRegister(NewSchedulerCollector())      // from scheduler.go
-	prometheus.MustRegister(NewQueueCollector())          // from queue.go
-	prometheus.MustRegister(NewNodesCollector())          // from nodes.go
-	prometheus.MustRegister(NewCPUsCollector())           // from cpus.go
 	prometheus.MustRegister(NewAccountsCollector())       // from accounts.go
-	prometheus.MustRegister(NewUsersCollector())          // from users.go
+	prometheus.MustRegister(NewCPUsCollector())           // from cpus.go
+	prometheus.MustRegister(NewGPUsCollector())           // from gpus.go
+	prometheus.MustRegister(NewNodesCollector())          // from nodes.go
 	prometheus.MustRegister(NewPartitionsCollector())     // from partitions.go
+	prometheus.MustRegister(NewQueueCollector())          // from queue.go
+	prometheus.MustRegister(NewSchedulerCollector())      // from scheduler.go
+	prometheus.MustRegister(NewUsersCollector())          // from users.go
 }
 
 var listenAddress = flag.String(


### PR DESCRIPTION
This pull request introduces the collection of GPU metrics through Slurm utilities. Other, more detailed metrics (such as GPU power draw) should be retrieved by specialized exporters.

```
type GPUsMetrics struct {
	alloc       float64
	idle        float64
	total       float64
	utilization float64
}
```

The inclusion of the `utilization` metric (reflects the total cluster GPU utilization) is debatable to be honest. It could be omitted if desired.

@vpenso Feedback would appreciated. The exporter is currently running on our GPU cluster. As you can probably tell, I'm not a seasoned Go programmer :)