### PR TITLE
Split tests into unit and system tests 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,12 @@ build:
 test:
 	@GOPATH=$(GOPATH) go test -v *.go
 
+unittest:
+	@GOPATH=$(GOPATH) go test -v --tags unit
+
+systemtest:
+	@GOPATH=$(GOPATH) go test -v --tags system
+
 run:
 	@GOPATH=$(GOPATH) go run $(GOFILES)
 

--- a/cpus_system_test.go
+++ b/cpus_system_test.go
@@ -1,4 +1,4 @@
-// +build unit
+// +build system
 
 /* Copyright 2017 Victor Penso, Matteo Dessalvi, Rovanion Luckey
 
@@ -18,17 +18,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 package main
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 )
 
-func TestParseQueueMetrics(t *testing.T) {
-	// Read the input data from a file
-	file, err := os.Open("test_data/squeue.txt")
-	if err != nil {
-		t.Fatalf("Can not open test data: %v", err)
-	}
-	data, err := ioutil.ReadAll(file)
-	t.Logf("%+v", ParseQueueMetrics(data))
+func TestCPUsGetMetrics(t *testing.T) {
+	t.Logf("%+v", CPUsGetMetrics())
 }

--- a/cpus_test.go
+++ b/cpus_test.go
@@ -1,4 +1,4 @@
-/* Copyright 2017 Victor Penso, Matteo Dessalvi
+/* Copyright 2017 Victor Penso, Matteo Dessalvi, Rovanion Luckey
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -31,6 +31,6 @@ func TestCPUsMetrics(t *testing.T) {
 	t.Logf("%+v", ParseCPUsMetrics(data))
 }
 
-func TestCPUssGetMetrics(t *testing.T) {
+func TestCPUsGetMetrics(t *testing.T) {
 	t.Logf("%+v", CPUsGetMetrics())
 }

--- a/cpus_test.go
+++ b/cpus_test.go
@@ -1,3 +1,5 @@
+// +build unit
+
 /* Copyright 2017 Victor Penso, Matteo Dessalvi, Rovanion Luckey
 
 This program is free software: you can redistribute it and/or modify
@@ -29,8 +31,4 @@ func TestCPUsMetrics(t *testing.T) {
 	}
 	data, err := ioutil.ReadAll(file)
 	t.Logf("%+v", ParseCPUsMetrics(data))
-}
-
-func TestCPUsGetMetrics(t *testing.T) {
-	t.Logf("%+v", CPUsGetMetrics())
 }

--- a/nodes_system_test.go
+++ b/nodes_system_test.go
@@ -1,4 +1,4 @@
-// +build unit
+// +build system
 
 /* Copyright 2017 Victor Penso, Matteo Dessalvi, Rovanion Luckey
 
@@ -18,17 +18,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 package main
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 )
 
-func TestParseQueueMetrics(t *testing.T) {
-	// Read the input data from a file
-	file, err := os.Open("test_data/squeue.txt")
-	if err != nil {
-		t.Fatalf("Can not open test data: %v", err)
-	}
-	data, err := ioutil.ReadAll(file)
-	t.Logf("%+v", ParseQueueMetrics(data))
+func TestNodesGetMetrics(t *testing.T) {
+	t.Logf("%+v", NodesGetMetrics())
 }

--- a/nodes_test.go
+++ b/nodes_test.go
@@ -1,4 +1,6 @@
-/* Copyright 2017 Victor Penso, Matteo Dessalvi
+// +build unit
+
+/* Copyright 2017 Victor Penso, Matteo Dessalvi, Rovanion Luckey
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -29,8 +31,4 @@ func TestNodesMetrics(t *testing.T) {
 	}
 	data, err := ioutil.ReadAll(file)
 	t.Logf("%+v", ParseNodesMetrics(data))
-}
-
-func TestNodesGetMetrics(t *testing.T) {
-	t.Logf("%+v", NodesGetMetrics())
 }

--- a/queue_system_test.go
+++ b/queue_system_test.go
@@ -1,4 +1,4 @@
-// +build unit
+// +build system
 
 /* Copyright 2017 Victor Penso, Matteo Dessalvi, Rovanion Luckey
 
@@ -18,17 +18,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 package main
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 )
 
-func TestParseQueueMetrics(t *testing.T) {
-	// Read the input data from a file
-	file, err := os.Open("test_data/squeue.txt")
-	if err != nil {
-		t.Fatalf("Can not open test data: %v", err)
-	}
-	data, err := ioutil.ReadAll(file)
-	t.Logf("%+v", ParseQueueMetrics(data))
+func TestQueueGetMetrics(t *testing.T) {
+	t.Logf("%+v", QueueGetMetrics())
 }

--- a/scheduler_system_test.go
+++ b/scheduler_system_test.go
@@ -1,4 +1,4 @@
-// +build unit
+// +build system
 
 /* Copyright 2017 Victor Penso, Matteo Dessalvi, Rovanion Luckey
 
@@ -18,17 +18,9 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>. */
 package main
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 )
 
-func TestParseQueueMetrics(t *testing.T) {
-	// Read the input data from a file
-	file, err := os.Open("test_data/squeue.txt")
-	if err != nil {
-		t.Fatalf("Can not open test data: %v", err)
-	}
-	data, err := ioutil.ReadAll(file)
-	t.Logf("%+v", ParseQueueMetrics(data))
+func TestSchedulerGetMetrics(t *testing.T) {
+	t.Logf("%+v", SchedulerGetMetrics())
 }

--- a/scheduler_test.go
+++ b/scheduler_test.go
@@ -1,4 +1,6 @@
-/* Copyright 2017 Victor Penso, Matteo Dessalvi
+// +build unit
+
+/* Copyright 2017 Victor Penso, Matteo Dessalvi, Rovanion Luckey
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -29,8 +31,4 @@ func TestSchedulerMetrics(t *testing.T) {
 	}
 	data, err := ioutil.ReadAll(file)
 	t.Logf("%+v", ParseSchedulerMetrics(data))
-}
-
-func TestSchedulerGetMetrics(t *testing.T) {
-	t.Logf("%+v", SchedulerGetMetrics())
 }


### PR DESCRIPTION
The system tests require a working slurm cluster to be present while running, or at least a working slurm controller. The unit tests operate within the confines of the Go code and are independent of the rest of the system.

`make test` still does the same thing as before, it runs all available tests. The commands `make unittest` and `make systemtest` were added for when only running tests within these categories are of interest.

These changes were motivated by me trying to package prometheus-slurm-exporter for Nix. Nix wants to run the available tests after a build is complete but is unable to provide services, such as a Slurm cluster, during the check phase of a build. Categorizing the tests in this way allows for some tests to run during the build of the package rather than none. 

The categories themselves are declared at the top of the Go source files through the `//build $xyz` header.