### PR TITLE
Enable GPUs accounting only via cmd line option (see #45)

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,7 +27,6 @@ func init() {
 	// Metrics have to be registered to be exposed
 	prometheus.MustRegister(NewAccountsCollector())       // from accounts.go
 	prometheus.MustRegister(NewCPUsCollector())           // from cpus.go
-	prometheus.MustRegister(NewGPUsCollector())           // from gpus.go
 	prometheus.MustRegister(NewNodesCollector())          // from nodes.go
 	prometheus.MustRegister(NewPartitionsCollector())     // from partitions.go
 	prometheus.MustRegister(NewQueueCollector())          // from queue.go
@@ -41,8 +40,19 @@ var listenAddress = flag.String(
 	":8080",
 	"The address to listen on for HTTP requests.")
 
+var gpuAcct = flag.Bool(
+	"gpus-acct",
+	false,
+	"Enable GPUs accounting")
+
 func main() {
 	flag.Parse()
+
+	// Turn on GPUs accounting only if the corresponding command line option is set to true.
+	if *gpuAcct {
+		prometheus.MustRegister(NewGPUsCollector())   // from gpus.go
+	}
+
 	// The Handler function provides a default handler to expose metrics
 	// via an HTTP server. "/metrics" is the usual endpoint for that.
 	log.Infof("Starting Server: %s", *listenAddress)


### PR DESCRIPTION
Don't enable GPU accounting by default but force its activation via command line option.