### PR TITLE
Add CPU metrics for pending jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,9 @@ See the related [test data](https://github.com/vpenso/prometheus-slurm-exporter/
 The following information about jobs are also extracted via [squeue](https://slurm.schedmd.com/squeue.html):
 
 * **Running/Pending/Suspended** jobs per SLURM Account.
+* **Running/Pending** CPUs per SLURM Account.
 * **Running/Pending/Suspended** jobs per SLURM User.
+* **Running/Pending** CPUs per SLURM User.
 
 ### Scheduler Information
 


### PR DESCRIPTION
These changes add two new metrics:

 - slurm_user_cpus_pending
 - slurm_account_cpus_pending

that track the number of cores requested by pending jobs for users or accounts.  Tests have been run and have succeeded in our environment.