### PR TITLE
Account for GPU type

### DIFF
--- a/gpus.go
+++ b/gpus.go
@@ -64,8 +64,8 @@ func ParseTotalGPUs() float64 {
 			if len(line) > 0 {
 				line = strings.Trim(line, "\"")
 				descriptor := strings.Fields(line)[1]
-				descriptor = strings.TrimPrefix(descriptor, "gpu:")
 				descriptor = strings.Split(descriptor, "(")[0]
+				descriptor = descriptor[strings.LastIndex(descriptor, ":")+1:]
 				node_gpus, _ :=  strconv.ParseFloat(descriptor, 64)
 				num_gpus += node_gpus
 			}


### PR DESCRIPTION
If GRES includes type "gpu:TYPE:COUNT", then total number is not reported. Here we grab the last value in this string as the GPU count.