### PR TITLE
Include all nodes in node.go and nodes.go if run as unprivileged user

### DIFF
--- a/cpus.go
+++ b/cpus.go
@@ -49,7 +49,7 @@ func ParseCPUsMetrics(input []byte) *CPUsMetrics {
 
 // Execute the sinfo command and return its output
 func CPUsData() []byte {
-	cmd := exec.Command("sinfo", "-h", "-o %C")
+	cmd := exec.Command("sinfo", "-h", "-a", "-o %C")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		log.Fatal(err)

--- a/node.go
+++ b/node.go
@@ -81,7 +81,7 @@ func ParseNodeMetrics(input []byte) map[string]*NodeMetrics {
 // NodeData executes the sinfo command to get data for each node
 // It returns the output of the sinfo command
 func NodeData() []byte {
-	cmd := exec.Command("sinfo", "-h", "-N", "-O", "NodeList: ,AllocMem: ,Memory: ,CPUsState: ,StateLong:")
+	cmd := exec.Command("sinfo", "-h", "-a", "-N", "-O", "NodeList: ,AllocMem: ,Memory: ,CPUsState: ,StateLong:")
 	out, err := cmd.Output()
 	if err != nil {
 		log.Fatal(err)

--- a/nodes.go
+++ b/nodes.go
@@ -112,7 +112,7 @@ func ParseNodesMetrics(input []byte) *NodesMetrics {
 
 // Execute the sinfo command and return its output
 func NodesData() []byte {
-	cmd := exec.Command("sinfo", "-h", "-o %D,%T")
+	cmd := exec.Command("sinfo", "-h", "-a", "-o %D,%T")
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
 		log.Fatal(err)


### PR DESCRIPTION
This is a similar fix than #20 we run the exporter as user prometheus and some nodes do not show up in `sinfo` by default as we have some nodes restricted to certain groups.