### PR TITLE
Update code to follow prometheus library and build system

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,22 @@
 PROJECT_NAME = prometheus-slurm-exporter
-SHELL := $(shell which bash) -eu -o pipefail
-
-GOPATH := $(shell pwd)/go/modules
+ROOTDIR := $(dir $(abspath $(firstword $(MAKEFILE_LIST))))
+SRCDIR := $(ROOTDIR)
+GOPATH := $(SRCDIR)/go/modules
 GOBIN := bin/$(PROJECT_NAME)
-GOFILES := $(shell ls *.go)
+GOFILES := $(wildcard $(SRCIR)/*.go)
+GOFLAGS = -v
+
+all: $(GOBIN)
+
+download: go/modules/pkg/mod
 
 .PHONY: build
-build: test $(GOBIN)
+build: $(GOBIN)
 
-$(GOBIN): go/modules/pkg/mod $(GOFILES)
+$(GOBIN): $(GOFILES)
 	mkdir -p bin
 	@echo "Building $(GOBIN)"
-	go build -v -o $(GOBIN)
+	go build $(GOFLAGS) -o $(GOBIN)
 
 go/modules/pkg/mod: go.mod
 	go mod download
@@ -23,6 +28,7 @@ test: go/modules/pkg/mod $(GOFILES)
 run: $(GOBIN)
 	$(GOBIN)
 
+.PHONY: clean
 clean:
 	go clean -modcache
 	rm -fr bin/ go/

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ GOPATH := $(SRCDIR)/go/modules
 GOBIN := bin/$(PROJECT_NAME)
 GOFILES := $(wildcard $(SRCIR)/*.go)
 GOFLAGS = -v
+GOTESTFLAGS =
 
 all: $(GOBIN)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,23 @@
 
 Prometheus collector and exporter for metrics extracted from the [Slurm](https://slurm.schedmd.com/overview.html) resource scheduling system.
 
+## Build from source
+
+
+with dependencies downloaded:
+- github.com/prometheus/client_golang
+- github.com/prometheus/common
+- github.com/stretchr/testify
+```bash
+make download
+make all
+```
+
+with dependencies already installed:
+```bash
+make all
+```
+
 ## Exported Metrics
 
 ### State of the CPUs

--- a/gpus.go
+++ b/gpus.go
@@ -17,7 +17,7 @@ package main
 
 import (
 	"github.com/prometheus/client_golang/prometheus"
-	"github.com/prometheus/common/log"
+	"log"
 	"io/ioutil"
 	"os/exec"
 	"strings"

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ import (
 	"flag"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
-	"github.com/prometheus/common/log"
+	"log"
 	"net/http"
 )
 
@@ -56,8 +56,8 @@ func main() {
 
 	// The Handler function provides a default handler to expose metrics
 	// via an HTTP server. "/metrics" is the usual endpoint for that.
-	log.Infof("Starting Server: %s", *listenAddress)
-	log.Infof("GPUs Accounting: %t", *gpuAcct)
+	log.Printf("Starting Server: %s", *listenAddress)
+	log.Printf("GPUs Accounting: %t", *gpuAcct)
 	http.Handle("/metrics", promhttp.Handler())
 	log.Fatal(http.ListenAndServe(*listenAddress, nil))
 }

--- a/packages/rpm/prometheus-slurm-exporter.spec
+++ b/packages/rpm/prometheus-slurm-exporter.spec
@@ -1,17 +1,20 @@
-%define        __spec_install_post %{nil}
-%define          debug_package %{nil}
-%define        __os_install_post %{_dbpath}/brp-compress
+%define debug_package %{nil}
+%global shortname prometheus-slurm-exporter
+%global goipath  github.com/vpenso/prometheus-slurm-exporter
+Version:        0.20
+%gometa
+%global golicenses      LICENSE
+%global godocs          README.md
 
-Name:           prometheus-slurm-exporter
-Version:        0.3
-Release:        1%{?dist}
+Name:           %{goname}
+Release:        %autorelease
 Summary:        Prometheus exporter for SLURM metrics
 Group:          Monitoring
 
 License:        GPL 3.0
-URL:            https://github.com/vpenso/prometheus-slurm-exporter
+URL:            %{gourl}
 
-Source0:        https://github.com/vpenso/prometheus-slurm-exporter/releases/download/%{version}/slurm_exporter-%{version}.linux-amd64.tar.gz
+Source0:        %{gosource}
 Source1:        prometheus-slurm-exporter.service
 Source2:        LICENSE
 Source3:        README.md
@@ -22,34 +25,29 @@ Requires(post): systemd
 Requires(preun): systemd
 Requires(postun): systemd
 %{?systemd_requires}
-BuildRequires:  systemd
-
-BuildRoot:      %{_tmppath}/%{name}-%{version}-1-root
+BuildRequires:  systemd-rpm-macros
+BuildRequires:  golang(github.com/prometheus/client_golang/prometheus)
+BuildRequires:  golang-github-prometheus-common-devel
 
 %description
 A Prometheus exporter for metrics extracted from the Slurm resource scheduling system.
 
 %prep
-%setup -q
+%goprep
+%autosetup -N -T -D -a 0 -n %{shortname}-%{version}
 
 %build
-# Empty section.
+%gobuild -o bin/%{shortname}
+
 
 %install
-rm -rf %{buildroot}
-mkdir -vp %{buildroot}
-mkdir -vp %{buildroot}%{_unitdir}/
-mkdir -vp %{buildroot}/usr/bin
-mkdir -vp %{buildroot}/usr/share/doc/prometheus-slurm-exporter-%{version}
-mkdir -vp %{buildroot}/var/lib/prometheus
-install -m 755 prometheus-slurm-exporter %{buildroot}/usr/bin/prometheus-slurm-exporter
-install -m 644 %{SOURCE1} %{buildroot}/usr/lib/systemd/system/prometheus-slurm-exporter.service
-install -m 644 %{SOURCE2} %{buildroot}/usr/share/doc/prometheus-slurm-exporter-%{version}/LICENSE
-install -m 644 %{SOURCE3} %{buildroot}/usr/share/doc/prometheus-slurm-exporter-%{version}/README.md
+install -m 0755 -vd %{buildroot}%{_bindir}
+install -m 0755 bin/%{shortname} %{buildroot}%{_bindir}
 
-%clean
-rm -rf %{buildroot}
- 
+install -m 0755 -vd %{buildroot}%{_unitdir}/
+install -m 0755 -vd  %{buildroot}/%{_sharedstatedir}/prometheus
+install -m 644 %{SOURCE1} %{buildroot}/%{_unitdir}/%{shortname}.service
+
 %pre
 getent group prometheus >/dev/null || groupadd -r prometheus
 getent passwd prometheus >/dev/null || \
@@ -58,27 +56,21 @@ getent passwd prometheus >/dev/null || \
 exit 0
 
 %post
-systemctl enable %{name}.service
-systemctl start %{name}.service
+systemctl enable --now %{shortname}.service
+%systemd_post %{shortname}.service
 
 %preun
-%systemd_preun %{name}.service
+%systemd_preun %{shortname}.service
 
 %postun
-%systemd_postun_with_restart %{name}.service
+%systemd_postun_with_restart %{shortname}.service
 
 %files
-%defattr(-,root,root,-)
-%doc LICENSE
+%license LICENSE
 %doc README.md
-%{_bindir}/prometheus-slurm-exporter
-%{_unitdir}/%{name}.service
-%attr(755, prometheus, prometheus)/var/lib/prometheus
+%{_bindir}/%{shortname}
+%{_unitdir}/%{shortname}.service
+%attr(755, prometheus, prometheus)/%{_sharedstatedir}/prometheus
 
 %changelog
-* Fri Feb 16 2018 Matteo <m.dessalvi@gsi.de> - 0.3
-- Fix issue #4
-* Wed Jan 31 2018 Matteo <m.dessalvi@gsi.de> - 0.2
-- Fix issue #3
-* Mon Dec 04 2017 Matteo <m.dessalvi@gsi.de> - 0.1
-- Full commit history: https://github.com/vpenso/prometheus-slurm-exporter/commits/master
+%autochangelog

--- a/packages/rpm/prometheus-slurm-exporter.spec
+++ b/packages/rpm/prometheus-slurm-exporter.spec
@@ -37,7 +37,7 @@ A Prometheus exporter for metrics extracted from the Slurm resource scheduling s
 %autosetup -N -T -D -a 0 -n %{shortname}-%{version}
 
 %build
-%gobuild -o bin/%{shortname}
+make all GOFLAGS=%{gobuildflags}
 
 
 %install


### PR DESCRIPTION
This pull request provides:
1. a code update in order to follow promotheus library indeed prometheus/common/log module is deprecated
2. Update makefile in order to allow offline build and to provides build flags
3. Update rpm spec file

